### PR TITLE
fix: keyring lookup uses 'server' attr for COSMIC/Qt compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ AI-native delivery pipeline for solo development: Linear, Notion, GitHub, Cursor
 | [docs/runbook.md](docs/runbook.md) | Code review, MCP, n8n, health |
 | [docs/definition-of-done.md](docs/definition-of-done.md) | DoR / DoD, naming |
 | [docs/mcp-setup.md](docs/mcp-setup.md) | MCP env vars for Cursor |
+| [docs/mcp-enable-howto.md](docs/mcp-enable-howto.md) | Как включить MCP (запуск Cursor с env из keyring, проверка) |
 | [docs/runbook-n8n.md](docs/runbook-n8n.md) | n8n on Podman |
 | [docs/notion-delivery-hub.md](docs/notion-delivery-hub.md) | Notion Delivery Hub structure |
 | [docs/linear-setup.md](docs/linear-setup.md) | Linear workflow, labels, GitHub link |
@@ -24,6 +25,8 @@ AI-native delivery pipeline for solo development: Linear, Notion, GitHub, Cursor
 | [docs/keyring-credentials.md](docs/keyring-credentials.md) | Keyring: шаблон записей, инвентарь ключей, токены/OAuth |
 | [docs/audit-and-history.md](docs/audit-and-history.md) | Что логируем и где смотреть историю |
 | [docs/current-phase.md](docs/current-phase.md) | Текущая фаза и следующие шаги |
+| [docs/stage2-mcp-automation.md](docs/stage2-mcp-automation.md) | Что агент с MCP делает на автопилоте (GitHub, Linear, Notion) |
+| [docs/agent-handoff-prompt.md](docs/agent-handoff-prompt.md) | Промпт для следующего чата — контекст и задача агенту |
 | [docs/notion-templates.md](docs/notion-templates.md) | Шаблоны Notion (Meeting, Spec, Runbook, ADR) — копировать |
 
 ## Stack
@@ -37,7 +40,7 @@ MCP servers: Notion, GitHub, Linear, Telegram, filesystem (see `.cursor/mcp.json
 
 ## Local setup
 
-1. Ключи в **keyring** по [docs/keyring-credentials.md](docs/keyring-credentials.md) (шаблон: Label, Password, User, Server). Затем `source scripts/load-env-from-keyring.sh` или `./scripts/load-env-from-keyring.sh --cursor`.
+1. Ключи в **keyring** по [docs/keyring-credentials.md](docs/keyring-credentials.md). Запуск Cursor с env: из любой папки **`aipipeline-cursor`** (после `ln -sf .../scripts/aipipeline-cursor.sh ~/.local/bin/aipipeline-cursor`) или из проекта: `./scripts/load-env-from-keyring.sh --cursor`.
 2. Либо `.env` из `.env.example` (не коммитить); см. [docs/mcp-setup.md](docs/mcp-setup.md).
 3. `npm ci` (или `npm install`).
 4. Cursor: Settings → MCP → Refresh после установки env.

--- a/docs/agent-handoff-prompt.md
+++ b/docs/agent-handoff-prompt.md
@@ -1,0 +1,26 @@
+# Промпт для следующего агента (копируй в новый чат)
+
+Скопируй блок ниже в новый чат с агентом (Cursor или Claude Code), чтобы быстро войти в контекст и продолжить с правильного места. Максимальная ИИ-автоматизация.
+
+---
+
+```
+Контекст: проект AIPipeline — AI-native delivery pipeline (PIPELINE.md). Solo-разработчик, Fedora COSMIC Atomic, 8 GB RAM. Source of truth: Linear (задачи), Notion (спеки, ADR), GitHub (код). Секреты только в keyring/env.
+
+Где остановились:
+- В keyring (wallet AIPipeline) уже есть: GitHub PAT, Linear API Key, Notion token. Права максимальные. Инвентарь и шаблон записей — в docs/keyring-credentials.md.
+- Репо: git инициализирован, первый коммит со scaffold (Phase 0.5 + Day-0 runbook, scripts, .cursor, .claude, docs). GitHub remote ещё не добавлен / не запушен — пользователь создаст репо и сделает push сам или уже сделал.
+- Загрузка env из keyring: на хосте выполнить `source scripts/load-env-from-keyring.sh` или `./scripts/load-env-from-keyring.sh --cursor` перед Cursor, чтобы MCP получил GITHUB_PERSONAL_ACCESS_TOKEN, LINEAR_API_KEY, NOTION_TOKEN. Скрипт поддерживает Linear и как linear.app, и как https://linear.app (GUI).
+
+Твоя задача (автопилот, по максимуму):
+1. Прочитай PIPELINE.md (обзор), docs/current-phase.md, docs/stage2-mcp-automation.md.
+2. Если у тебя есть доступ к MCP (Notion, GitHub, Linear) — выполни всё из stage2-mcp-automation.md: GitHub — labels, branch protection; Linear — проект, workflow states, labels (технические, приоритет, agent-ready); Notion — Delivery Hub, базы (Meetings, Specs, Decisions, Integrations, Risks, Access Matrix, Sprint Log), шаблоны из docs/notion-templates.md, Quick Links. Всё по современным практикам и заточка под AI (единые имена, agent-ready labels).
+3. Обнови docs/current-phase.md — что сделано по пунктам выше; при необходимости docs/keyring-credentials.md (инвентарь).
+4. Что нельзя сделать через MCP (OAuth в браузере, создание репо, Telegram/Sentry/n8n) — оформи как короткий чек-лист "осталось вручную" в current-phase или в комментарии пользователю.
+
+Правила: .cursor/rules (workflow, coding-standards, integration-standards, docs-policy); секреты только в keyring/env; не коммитить .env и токены. Документация проекта — в docs/; runbook — docs/runbook.md, docs/day0-runbook.md.
+```
+
+---
+
+После вставки промпта агент получит контекст и список действий; при наличии MCP сможет выполнить Stage 2 без дополнительных вопросов.

--- a/docs/current-phase.md
+++ b/docs/current-phase.md
@@ -9,18 +9,19 @@
 - **Фаза 0.5:** проверка среды, мини-интервью, Ready/Setup списки, план реализован.
 - **Скелет репо:** .github (PR/issue templates, CI, deploy stubs), .cursor (mcp.json, rules, commands), .claude (agents, CLAUDE.md), docs (runbooks, гайды, keyring, audit), scripts (system-check, load-env-from-keyring, run-n8n).
 - **Keyring и аудит:** [keyring-credentials.md](keyring-credentials.md), [audit-and-history.md](audit-and-history.md); токены/OAuth, инвентарь ключей.
-- **Toolbox:** контейнер `aipipeline` создан. Внутри него по умолчанию нет Node/Podman — они на хосте. Чтобы иметь Node в toolbox: `toolbox enter aipipeline` → `./scripts/setup-toolbox-aipipeline.sh`. Claude Code: алиас `claude` в ~/.bashrc (npx) на хосте.
+- **Toolbox:** контейнер `aipipeline` создан; Node в toolbox установлен (`./scripts/setup-toolbox-aipipeline.sh`). Claude Code: алиас `claude` в ~/.bashrc (npx) на хосте.
+- **Keyring:** в связке AIPipeline уже лежат **GitHub PAT**, **Linear API Key**, **Notion token** (инвентарь в [keyring-credentials.md](keyring-credentials.md)). Права — максимальные где задаётся.
 
 ---
 
-## Текущий фокус: Фаза 1 (Day-0)
+## Текущий фокус: Stage 2 (MCP-автоматизация) + остаток Day-0
 
-Конвейер пока не подключён к живым сервисам. Нужно по порядку:
+**Сделано по ключам:** GitHub PAT, Linear, Notion — в keyring. Репо инициализирован (git, первый коммит).
 
-1. **GitHub** — создать репо (или использовать существующий), запушить этот scaffold, branch protection, labels, **PAT** → в keyring ([keyring-credentials.md](keyring-credentials.md)).
-2. **Linear** — workspace, проект, workflow и labels, интеграция с GitHub, **API Key** → keyring.
-3. **Notion** — workspace, Delivery Hub (базы + шаблоны из [notion-templates.md](notion-templates.md)), **Internal Integration token** → keyring.
-4. **Cursor** — Integrations (GitHub, Linear), env из keyring (`./scripts/load-env-from-keyring.sh --cursor`), MCP Refresh.
+**Дальше (максимум на автопилоте):**
+1. Запускать Cursor с env из keyring: `./scripts/load-env-from-keyring.sh --cursor` (на хосте). MCP Refresh → зелёные Notion, GitHub, Linear.
+2. **Агент с MCP** выполняет по [stage2-mcp-automation.md](stage2-mcp-automation.md): GitHub (labels, branch protection), Linear (проект, workflow, labels), Notion (Delivery Hub, базы, шаблоны). Всё по лучшим практикам и PIPELINE.
+3. Остаток Day-0: Cursor Integrations (GitHub/Linear OAuth в браузере), Sentry, Telegram, n8n — по [day0-runbook.md](day0-runbook.md).
 5. **Sentry** — проект, DSN (при необходимости в keyring); Sentry MCP — OAuth в Cursor.
 6. **Telegram** — бот, группа, **token + Chat ID** → keyring.
 7. **n8n** — Podman ([runbook-n8n.md](runbook-n8n.md)), credentials в UI; при желании логин/пароль n8n тоже в keyring.

--- a/docs/mcp-enable-howto.md
+++ b/docs/mcp-enable-howto.md
@@ -1,0 +1,70 @@
+# Как включить MCP (GitHub, Linear, Notion) в Cursor
+
+Чтобы агент в Cursor имел доступ к API GitHub, Linear и Notion через MCP, нужны переменные окружения с токенами. Ключи уже в keyring — их нужно подставить в env **до** запуска Cursor.
+
+## Вариант 1: Одна команда из любой папки (рекомендуется)
+
+После однократной настройки (уже сделано: симлинк в `~/.local/bin`) можно запускать Cursor с env **из любой папки**:
+
+```bash
+aipipeline-cursor
+```
+
+Команда переходит в проект, подгружает переменные из keyring и запускает Cursor. Если симлинка нет: `ln -sf /var/home/user/Projects/AIPipeline/scripts/aipipeline-cursor.sh ~/.local/bin/aipipeline-cursor` (убедись, что `~/.local/bin` в PATH).
+
+---
+
+## Вариант 2: Запуск из каталога проекта
+
+1. Закрой Cursor, если открыт.
+2. Открой **обычный терминал на хосте** (не toolbox).
+3. Выполни:
+   ```bash
+   cd /var/home/user/Projects/AIPipeline
+   source scripts/load-env-from-keyring.sh
+   cursor .   # или твой способ запуска: путь к AppImage, flatpak run и т.д.
+   ```
+   Или одной командой:
+   ```bash
+   cd /var/home/user/Projects/AIPipeline && ./scripts/load-env-from-keyring.sh --cursor
+   ```
+   Скрипт сам ищет Cursor: сначала в PATH, потом `CURSOR_APPIMAGE`, затем `Cursor*.AppImage` в каталогах `~/Apps`, `~/.local/bin`. Если найден — запускает его с env. Если нет — загрузит env и откроет shell; **запусти Cursor вручную из этого же терминала** (например через команду из меню приложений или полный путь к AppImage), чтобы процесс Cursor унаследовал переменные.
+4. Cursor запустится с уже подставленными `GITHUB_PERSONAL_ACCESS_TOKEN`, `LINEAR_API_KEY`, `NOTION_TOKEN`. Открой проект AIPipeline.
+5. В Cursor: **Settings** (Ctrl+,) → **MCP** → **Refresh**. Должны стать зелёными: Notion, GitHub, Linear, filesystem (Telegram — когда добавишь токены).
+6. Новый чат с агентом в этом проекте будет видеть MCP и сможет выполнять [stage2-mcp-automation.md](stage2-mcp-automation.md).
+
+## Вариант 3: Профиль терминала «AIPipeline (env)»
+
+В Cursor открыт проект AIPipeline → в панели терминала выбери профиль **«AIPipeline (env)»** (выпадающий список рядом с `+`). Терминал откроется в каталоге проекта с env, загруженным из keyring. Для **уже запущенного** Cursor это не подставит env в процесс Cursor (MCP читает env процесса Cursor при старте). Поэтому для MCP по-прежнему лучше запускать Cursor из терминала по варианту 1. Профиль удобен, чтобы в терминале запускать команды (npm, git, скрипты) с уже подставленными переменными.
+
+## Какой профиль терминала выбирать (в Cursor)
+
+В выпадающем списке терминала (стрелка рядом с `+`):
+
+- **AIPipeline (host)** — обычный bash в каталоге проекта. Выбирай как **профиль по умолчанию** для этого воркспейса (Select Default Profile → AIPipeline (host)), чтобы новые терминалы открывались в проекте.
+- **AIPipeline (env)** — то же, но в этом терминале уже подставлены переменные из keyring (удобно для `npm run`, скриптов). Не даёт env в сам процесс Cursor/MCP — только в этот терминал.
+- Остальные (bash, Distrobox VoiceForge и т.д.) — по необходимости. Для работы в AIPipeline достаточно AIPipeline (host) по умолчанию.
+
+## Проверка
+
+- В чате с агентом: «Покажи мои Linear workspace» или «Найди в Notion страницы с Delivery Hub». Если MCP подключён, агент сможет вызвать инструменты и вернуть результат.
+- Settings → MCP: у серверов Notion, GitHub, Linear статус должен быть зелёный.
+
+## Если Linear / Telegram показывают Error (красная точка)
+
+В логе будет что-то вроде `LINEAR_API_KEY environment variable is required` или `TELEGRAM_BOT_TOKEN` required. Это значит, что **процесс Cursor запущен без env из keyring**.
+
+**Что сделать:** полностью закрой Cursor и снова запусти его **только** через команду в терминале:
+```bash
+aipipeline-cursor
+```
+После этого Settings → MCP → **Refresh**. Linear (и при наличии ключей Telegram) должны стать зелёными. Telegram будет красным, пока не добавишь бота и не положишь токен и Chat ID в keyring — это нормально.
+
+## Если видишь «MCP configuration errors: JSON syntax error: Unexpected end of JSON input»
+
+Это значит, что **глобальный** конфиг Cursor (`~/.cursor/mcp.json`) пустой или битый. Cursor его парсит и падает. Исправление: записать в `~/.cursor/mcp.json` валидный JSON, например `{"mcpServers":{}}`. Серверы для AIPipeline берутся из конфига проекта (`.cursor/mcp.json` в репо).
+
+## Если MCP не видит токены
+
+- Cursor при старте наследует env только от родительского процесса. Если ты открыл Cursor из лаунчера/иконки, env из keyring в него не попал. Запусти Cursor из терминала по варианту 1.
+- Убедись, что ключи в keyring с атрибутами `service`/`user` как в [keyring-credentials.md](keyring-credentials.md) (для CLI: `secret-tool lookup service github.com user aipipeline` и т.п. должны возвращать значение).

--- a/docs/stage2-mcp-automation.md
+++ b/docs/stage2-mcp-automation.md
@@ -1,0 +1,48 @@
+# Stage 2: что агент с MCP может сделать на автопилоте
+
+После того как в keyring лежат **GitHub PAT**, **Linear API Key**, **Notion token**, агент с подключёнными MCP (в Cursor или Claude Code) может выполнить максимум настроек без ручного ввода.
+
+## Перед стартом
+
+- На **хосте** (не в toolbox): `source scripts/load-env-from-keyring.sh` или запуск Cursor через `./scripts/load-env-from-keyring.sh --cursor`, чтобы MCP получил env с токенами.
+- Cursor → Settings → MCP → Refresh; убедиться, что Notion, GitHub, Linear в статусе OK.
+
+---
+
+## Linear (через Linear MCP)
+
+- Получить список workspace, команд, проектов.
+- **Создать/проверить workflow states:** Triage → Backlog → Ready → In Progress → In Review → Blocked → Done → Cancelled (если API позволяет).
+- **Создать labels:** технические (`integration`, `bugfix`, `feature`, `docs`, `devops`, `observability`, `security`, `refactor`), приоритет (`P0-Critical`, `P1-High`, `P2-Medium`, `P3-Low`), AI (`agent-ready`, `needs-human`, `needs-review`), инциденты (`bug-critical`, `bug-major`, `bug-minor`). См. [linear-setup.md](linear-setup.md), PIPELINE Фаза 3.
+- **Создать проект** для AIPipeline, если ещё нет.
+- **Интеграция GitHub:** делается в UI Linear (Settings → Integrations → GitHub); после подключения — проверить через MCP, что issue линкуются с PR.
+
+---
+
+## Notion (через Notion MCP)
+
+- **Найти или создать** корневую страницу Delivery Hub.
+- **Создать базы** (если MCP/API позволяет создание): Meetings, Specs, Decisions, Integrations, Risks & Issues, Access Matrix, Sprint Log. Свойства по [notion-delivery-hub.md](notion-delivery-hub.md).
+- **Создать страницы-шаблоны** из [notion-templates.md](notion-templates.md): Meeting, Spec (RFC), Integration Mapping, Runbook, ADR — как дочерние страницы или шаблоны в базах.
+- **Quick Links:** страница со ссылками на Linear, GitHub repo, n8n, Sentry, Telegram (URL подставить после того как они появятся).
+- Убедиться, что интеграция (Internal Integration) имеет доступ ко всем нужным страницам/базам (Share → Connect to integration).
+
+---
+
+## GitHub (через GitHub MCP)
+
+- **Проверить репо:** что scaffold запушен, ветка `main` есть.
+- **Labels:** создать по [github-branch-protection.md](github-branch-protection.md): bug, feature, documentation, P0-Critical … P3-Low (цвета и описания).
+- **Branch protection:** через API или вручную в Settings → Branches: require PR, require status checks (lint, build, test).
+- **Issue/PR templates:** уже в репо (.github/); проверить, что они подхватываются.
+
+---
+
+## Порядок (рекомендуемый)
+
+1. **GitHub** — labels, branch protection (если ещё не сделано).
+2. **Linear** — проект, workflow, labels; интеграция с GitHub в UI.
+3. **Notion** — Delivery Hub, базы, шаблоны, Quick Links.
+4. Обновить [current-phase.md](current-phase.md) и при необходимости [keyring-credentials.md](keyring-credentials.md) (инвентарь).
+
+Всё по современным практикам и по PIPELINE; заточка под AI: единые имена, labels для agent-ready, связка Linear ↔ GitHub ↔ Notion.

--- a/scripts/aipipeline-cursor.sh
+++ b/scripts/aipipeline-cursor.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Запуск Cursor с env из keyring для AIPipeline. Можно вызывать из любой папки.
+# Один раз добавь в PATH: ln -sf /var/home/user/Projects/AIPipeline/scripts/aipipeline-cursor.sh ~/.local/bin/aipipeline-cursor
+# Дальше из любой папки: aipipeline-cursor
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+[[ -L "$SCRIPT_PATH" ]] && SCRIPT_PATH=$(readlink -f "$SCRIPT_PATH" 2>/dev/null || realpath "$SCRIPT_PATH" 2>/dev/null)
+PROJECT_ROOT=$(cd "$(dirname "$SCRIPT_PATH")/.." && pwd)
+exec "$PROJECT_ROOT/scripts/load-env-from-keyring.sh" --cursor


### PR DESCRIPTION
## Summary
- Fix `load-env-from-keyring.sh` to use `server` attribute (not `service`) matching COSMIC/Qt keychain `org.qt.keychain` schema
- Falls back to `service` for CLI-created entries
- Add `aipipeline-cursor` wrapper script for one-command launch
- Update `keyring-credentials.md` docs with correct attribute names
- Add MCP enable howto, agent handoff prompt, and stage2 automation docs

## Test plan
- [x] `source scripts/load-env-from-keyring.sh` now finds GitHub PAT, Linear API Key, and Notion token from GUI-created keyring entries
- [x] `aipipeline-cursor` launches Cursor with env loaded

Made with [Cursor](https://cursor.com)