### PR TITLE
ops: improve post-reboot one-command startup

### DIFF
--- a/docs/post-reboot-runbook.md
+++ b/docs/post-reboot-runbook.md
@@ -6,14 +6,15 @@
 
 ## Одна команда (рекомендуется)
 
-Если уже настроен Cloudflare Tunnel и n8n хотя бы раз запускался через `run-n8n-with-cloudflared.sh`:
+Если уже настроен Cloudflare Tunnel и baseline stack scripts в репо:
 
 ```bash
 cd /var/home/user/Projects/AIPipeline
 ./scripts/start-after-reboot.sh
 ```
 
-Поднимает: user-сервис cloudflared → n8n (Podman) → приложение (Node). Проверка: `./scripts/stack-control.sh status core`.
+Поднимает профиль `full`: app + n8n + observability + cloudflared, затем проверяет `/health` и `/healthz`.  
+Проверка статуса: `./scripts/stack-control.sh status full`.
 
 ---
 
@@ -43,16 +44,16 @@ curl -sS https://n8n.aipipeline.cc/ -o /dev/null -w "%{http_code}\n"
 
 ---
 
-## Вариант B: Всё одной командой (core: app + n8n)
+## Вариант B: Минимальный режим без observability
 
-Без туннеля (только localhost; Telegram webhook не будет работать без HTTPS):
+Если нужен только `core` (app + n8n) и вы не хотите поднимать observability:
 
 ```bash
 cd /var/home/user/Projects/AIPipeline
-./scripts/stack-control.sh start core
+./scripts/start-after-reboot.sh --no-observability
 ```
 
-С туннелем (стабильный URL) — после перезагрузки лучше использовать вариант A.
+Для статуса: `./scripts/stack-control.sh status core`.
 
 ---
 

--- a/docs/post-reboot-runbook.md
+++ b/docs/post-reboot-runbook.md
@@ -13,7 +13,7 @@ cd /var/home/user/Projects/AIPipeline
 ./scripts/start-after-reboot.sh
 ```
 
-Поднимает профиль `full`: app + n8n + observability + cloudflared, затем проверяет `/health` и `/healthz`.  
+Поднимает профиль `full`: app + n8n + observability + cloudflared, затем проверяет `/health` и `/healthz`.
 Проверка статуса: `./scripts/stack-control.sh status full`.
 
 ---

--- a/scripts/start-after-reboot.sh
+++ b/scripts/start-after-reboot.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
-# One-command startup after reboot: cloudflared (user service), n8n with stable WEBHOOK_URL, app.
-# Use when stable HTTPS is configured (Cloudflare Tunnel).
-# Usage: ./scripts/start-after-reboot.sh
+# One-command startup after reboot.
+# Starts full local stack (app + n8n + observability + cloudflared), then probes health endpoints.
+#
+# Usage:
+#   ./scripts/start-after-reboot.sh
+#   ./scripts/start-after-reboot.sh --no-observability   # start only core + cloudflared
 
 set -euo pipefail
 
@@ -9,26 +12,55 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 
-echo "=== AIPipeline post-reboot start ==="
-
-# 1. Cloudflared tunnel (user systemd)
-if systemctl --user is-active --quiet aipipeline-cloudflared.service 2>/dev/null; then
-  echo "cloudflared: already running"
-else
-  echo "Starting cloudflared..."
-  systemctl --user start aipipeline-cloudflared.service || {
-    echo "Warning: cloudflared not started (install with ./scripts/install-cloudflared-user-service.sh)" >&2
-  }
+PROFILE="full"
+if [[ "${1:-}" == "--no-observability" ]]; then
+  PROFILE="core"
 fi
 
-# 2. n8n (existing container already has WEBHOOK_URL if created via run-n8n-with-cloudflared.sh)
-source "$SCRIPT_DIR/load-env-from-keyring.sh" 2>/dev/null || true
-"$SCRIPT_DIR/run-n8n.sh"
-echo "n8n: running"
+echo "=== AIPipeline post-reboot start ==="
+echo "Profile: $PROFILE"
 
-# 3. App (for /status)
-"$SCRIPT_DIR/stack-control.sh" start core
-echo "app: started"
+source "$SCRIPT_DIR/load-env-from-keyring.sh" 2>/dev/null || true
+
+"$SCRIPT_DIR/stack-control.sh" start "$PROFILE"
 
 echo ""
-echo "Done. Check: ./scripts/stack-control.sh status core"
+echo "Waiting for app /health..."
+for _ in {1..20}; do
+  if curl -fsS "http://127.0.0.1:3000/health" >/dev/null 2>&1; then
+    echo "app: healthy"
+    break
+  fi
+  sleep 1
+done
+
+if ! curl -fsS "http://127.0.0.1:3000/health" >/dev/null 2>&1; then
+  echo "app: health probe failed after startup" >&2
+  echo "Hint: ./scripts/stack-control.sh restart $PROFILE" >&2
+  exit 1
+fi
+
+echo "Waiting for n8n /healthz..."
+for _ in {1..20}; do
+  if curl -fsS "http://127.0.0.1:5678/healthz" >/dev/null 2>&1; then
+    echo "n8n: healthy"
+    break
+  fi
+  sleep 1
+done
+
+if ! curl -fsS "http://127.0.0.1:5678/healthz" >/dev/null 2>&1; then
+  echo "n8n: health probe failed after startup" >&2
+  echo "Hint: ./scripts/stack-control.sh restart $PROFILE" >&2
+  exit 1
+fi
+
+echo ""
+"$SCRIPT_DIR/stack-control.sh" status "$PROFILE"
+
+echo ""
+echo "Done."
+echo "Next checks:"
+echo "  source scripts/load-env-from-keyring.sh"
+echo "  ./scripts/check-wf5-command-routing.sh --limit 15"
+echo "  ./scripts/check-telegram-uat-evidence.sh --since-minutes 180 --limit 200"


### PR DESCRIPTION
## Summary
- refactor start-after-reboot to use unified stack-control profile startup
- default to full profile (app + n8n + observability + cloudflared)
- add explicit health probes for app (/health) and n8n (/healthz)
- update reboot runbook to match the new startup path

## Validation
- ./scripts/start-after-reboot.sh --no-observability
- npm run -s docs:check-links